### PR TITLE
upgrade node-hid to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.2",
     "author": "Ben Hutchison <ben@aldaviva.com> (http://aldaviva.com)",
     "dependencies": {
-		"node-hid": "0.3.1"
+		"node-hid": "^0.5.4"
     },
     "bugs": {
 		"url": "https://github.com/Aldaviva/WebScale/issues"


### PR DESCRIPTION
node-hid@0.3.1 cannot be installed from npm due to a package that has since been removed.